### PR TITLE
Enum immutable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,11 @@
       "Damianopetrungaro\\CleanArchitecture\\": "src/"
     }
   },
+  "autoload-dev": {
+    "psr-4": {
+      "Damianopetrungaro\\CleanArchitecture\\Unit\\": "tests/Unit/"
+    }
+  },
   "require": {
     "php": ">=7.1"
   },

--- a/src/Common/Enum/Enum.php
+++ b/src/Common/Enum/Enum.php
@@ -21,12 +21,17 @@ abstract class Enum implements EnumInterface
      */
     private $value;
 
+    /**
+     * Enum constructor.
+     *
+     * @param string $value
+     */
     public function __construct(string $value)
     {
         if (!static::isValid($value)) {
-            throw new \InvalidArgumentException("$value is not available in " . static::class);
+            throw new \InvalidArgumentException(sprintf('The value "%s" is not available in %s', $value, static::class));
         }
-
+        
         $this->value = $value;
     }
 
@@ -35,10 +40,7 @@ abstract class Enum implements EnumInterface
      */
     public static function __callStatic(string $value, array $args = []): EnumInterface
     {
-        $self = new ReflectionClass(static::class);
-        $constants = $self->getConstants();
-
-        if (!array_key_exists($value, $constants)) {
+        if (!static::isValid($value)) {
             throw new \InvalidArgumentException(sprintf('The value "%s" is not available in %s', $value, static::class));
         }
 
@@ -53,11 +55,19 @@ abstract class Enum implements EnumInterface
         return $this->value;
     }
 
-    public function isValid(string $value): bool
+    /**
+     * Check if the value is available as constant
+     *
+     * @params string $value
+     *
+     * @return bool
+     */
+    private static function isValid(string $value): bool
     {
         $self = new ReflectionClass(static::class);
+        $constants = $self->getConstants();
 
-        return in_array($value, $self->getConstants(), true);
+        return array_key_exists($value, $constants));
     }
 
     /**

--- a/src/Common/Enum/Enum.php
+++ b/src/Common/Enum/Enum.php
@@ -14,12 +14,21 @@ use ReflectionClass;
  * protected const ENTITY_NOT_FOUND = 'ENTITY_NOT_FOUND';
  * protected const PERSISTENCE_ERROR= 'PERSISTENCE_ERROR';
  */
-class Enum implements EnumInterface
+abstract class Enum implements EnumInterface
 {
     /**
      * @var string $value
      */
     private $value;
+
+    public function __construct(string $value)
+    {
+        if (!static::isValid($value)) {
+            throw new \InvalidArgumentException("$value is not available in " . static::class);
+        }
+
+        $this->value = $value;
+    }
 
     /**
      * {@inheritDoc}
@@ -29,14 +38,11 @@ class Enum implements EnumInterface
         $self = new ReflectionClass(static::class);
         $constants = $self->getConstants();
 
-        if (!isset($constants[$value])) {
-            throw new \InvalidArgumentException("$value is not available in " . static::class);
+        if (!array_key_exists($value, $constants)) {
+            throw new \InvalidArgumentException(sprintf('The value "%s" is not available in %s', $value, static::class));
         }
 
-        $enum = new static();
-        $enum->value = $constants[$value];
-
-        return $enum;
+        return new static($constants[$value]);
     }
 
     /**
@@ -45,5 +51,20 @@ class Enum implements EnumInterface
     public function getValue(): string
     {
         return $this->value;
+    }
+
+    public function isValid(string $value): bool
+    {
+        $self = new ReflectionClass(static::class);
+
+        return in_array($value, $self->getConstants(), true);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __toString(): string
+    {
+        return $this->getValue();
     }
 }

--- a/src/Common/Enum/Enum.php
+++ b/src/Common/Enum/Enum.php
@@ -22,16 +22,17 @@ abstract class Enum implements EnumInterface
     private $value;
 
     /**
-     * Enum constructor.
-     *
-     * @param string $value
+     * {@inheritDoc}
      */
     public function __construct(string $value)
     {
-        if (!static::isValid($value)) {
+        $self = new ReflectionClass(static::class);
+        $constants = $self->getConstants();
+
+        if (!array_key_exists($value, $constants)) {
             throw new \InvalidArgumentException(sprintf('The value "%s" is not available in %s', $value, static::class));
         }
-        
+
         $this->value = $value;
     }
 
@@ -40,11 +41,7 @@ abstract class Enum implements EnumInterface
      */
     public static function __callStatic(string $value, array $args = []): EnumInterface
     {
-        if (!static::isValid($value)) {
-            throw new \InvalidArgumentException(sprintf('The value "%s" is not available in %s', $value, static::class));
-        }
-
-        return new static($constants[$value]);
+        return new static($value);
     }
 
     /**
@@ -53,21 +50,6 @@ abstract class Enum implements EnumInterface
     public function getValue(): string
     {
         return $this->value;
-    }
-
-    /**
-     * Check if the value is available as constant
-     *
-     * @params string $value
-     *
-     * @return bool
-     */
-    private static function isValid(string $value): bool
-    {
-        $self = new ReflectionClass(static::class);
-        $constants = $self->getConstants();
-
-        return array_key_exists($value, $constants));
     }
 
     /**

--- a/src/Common/Enum/EnumInterface.php
+++ b/src/Common/Enum/EnumInterface.php
@@ -34,13 +34,6 @@ interface EnumInterface
     public function getValue(): string;
 
     /**
-     * Check if the value is a valid Enum value
-     *
-     * @return bool
-     */
-    public function isValid(string $value): bool;
-
-    /**
      * Return the enum value
      *
      * @return string

--- a/src/Common/Enum/EnumInterface.php
+++ b/src/Common/Enum/EnumInterface.php
@@ -34,6 +34,13 @@ interface EnumInterface
     public function getValue(): string;
 
     /**
+     * Check if the value is a valid Enum value
+     *
+     * @return bool
+     */
+    public function isValid(string $value): bool;
+
+    /**
      * Return the enum value
      *
      * @return string

--- a/src/Common/Enum/EnumInterface.php
+++ b/src/Common/Enum/EnumInterface.php
@@ -15,6 +15,13 @@ namespace Damianopetrungaro\CleanArchitecture\Common\Enum;
 interface EnumInterface
 {
     /**
+     * Enum constructor.
+     *
+     * @param string $value
+     */
+    public function __construct(string $value);
+
+    /**
      * Throw an exception if there's no constant in the child class, otherwise return the constant value.
      *
      * @param string $enum

--- a/src/Common/Enum/EnumInterface.php
+++ b/src/Common/Enum/EnumInterface.php
@@ -32,4 +32,11 @@ interface EnumInterface
      * @return string
      */
     public function getValue(): string;
+
+    /**
+     * Return the enum value
+     *
+     * @return string
+     */
+    public function __toString(): string;
 }

--- a/tests/Unit/Common/Enum/EnumTest.php
+++ b/tests/Unit/Common/Enum/EnumTest.php
@@ -1,7 +1,6 @@
 <?php
 namespace Damianopetrungaro\CleanArchitecture\Unit\Common\Enum;
 
-use Damianopetrungaro\CleanArchitecture\Common\Enum\Enum;
 use Damianopetrungaro\CleanArchitecture\Common\Enum\EnumInterface;
 use Damianopetrungaro\CleanArchitecture\Unit\Common\Enum\Fixtures\MyEnum;
 use PHPUnit\Framework\TestCase;
@@ -13,14 +12,14 @@ class EnumTest extends TestCase
      *
      * @expectedException \InvalidArgumentException
      */
-    public function testInvalidArgumentException()
+    public function testCallStaticInvalidArgumentException()
     {
         $this->expectException(\InvalidArgumentException::class);
-        Enum::NOT_EXISTS();
+        MyEnum::NOT_EXISTS();
     }
 
     /**
-     * Check that an InvalidArgumentException is thrown
+     * Check that an InvalidArgumentException is thrown using the Enum constructor
      *
      * @expectedException \InvalidArgumentException
      */
@@ -34,7 +33,7 @@ class EnumTest extends TestCase
      * Check that the call static method return the expected value
      *
      */
-    public function testValidEnumConstructor()
+    public function testConstructorValidEnum()
     {
         $firstEnum = new MyEnum(MyEnum::VALUE_A);
         $secondEnum = new MyEnum(MyEnum::VALUE_B);
@@ -44,26 +43,41 @@ class EnumTest extends TestCase
         $this->assertTrue($secondEnum instanceof EnumInterface);
         $this->assertTrue($thirdEnum instanceof EnumInterface);
 
-        $this->assertEquals($firstEnum->getValue(), 'A');
-        $this->assertEquals($secondEnum->getValue(), 'B');
-        $this->assertEquals($thirdEnum->getValue(), 'C');
+        $this->assertEquals($firstEnum->getValue(), 'VALUE_A');
+        $this->assertEquals($secondEnum->getValue(), 'VALUE_B');
+        $this->assertEquals($thirdEnum->getValue(), 'VALUE_C');
     }
 
     /**
      * Check that the call static method return the expected value
      */
-    public function testValidEnumFactory()
+    public function testCallStaticValidEnum()
     {
+        /** @var EnumInterface $firstEnum */
         $firstEnum = MyEnum::VALUE_A();
+
+        /** @var EnumInterface $secondEnum */
         $secondEnum = MyEnum::VALUE_B();
+
+        /** @var EnumInterface $thirdEnum */
         $thirdEnum = MyEnum::VALUE_C();
 
         $this->assertTrue($firstEnum instanceof EnumInterface);
         $this->assertTrue($secondEnum instanceof EnumInterface);
         $this->assertTrue($thirdEnum instanceof EnumInterface);
 
-        $this->assertEquals($firstEnum->getValue(), 'A');
-        $this->assertEquals($secondEnum->getValue(), 'B');
-        $this->assertEquals($thirdEnum->getValue(), 'C');
+        $this->assertEquals($firstEnum->getValue(), 'VALUE_A');
+        $this->assertEquals($secondEnum->getValue(), 'VALUE_B');
+        $this->assertEquals($thirdEnum->getValue(), 'VALUE_C');
+    }
+
+    /**
+     * Check that the toString magic method return valid value
+     */
+    public function testToStringMagicMethod()
+    {
+        $enum = new MyEnum(MyEnum::VALUE_A);
+
+        $this->assertEquals((string)$enum, MyEnum::VALUE_A);
     }
 }

--- a/tests/Unit/Common/Enum/EnumTest.php
+++ b/tests/Unit/Common/Enum/EnumTest.php
@@ -5,6 +5,13 @@ use Damianopetrungaro\CleanArchitecture\Common\Enum\Enum;
 use Damianopetrungaro\CleanArchitecture\Common\Enum\EnumInterface;
 use PHPUnit\Framework\TestCase;
 
+class MyEnum extends Enum
+{
+    protected const CONSTANT_NAME = 'this is a value';
+    protected const ANOTHER_CONSTANT_NAME = 'ANOTHER_CONSTANT_NAME';
+    protected const LAST_CONSTANT_NAME = 'Last!';
+}
+
 class EnumTest extends TestCase
 {
     /**
@@ -24,17 +31,9 @@ class EnumTest extends TestCase
      */
     public function testValidEnum()
     {
-        $extendedEnum = new class extends Enum
-        {
-            protected const CONSTANT_NAME = 'this is a value';
-            protected const ANOTHER_CONSTANT_NAME = 'ANOTHER_CONSTANT_NAME';
-            protected const LAST_CONSTANT_NAME = 'Last!';
-        };
-
-        $firstEnum = $extendedEnum::CONSTANT_NAME();
-        $secondEnum = $extendedEnum::ANOTHER_CONSTANT_NAME();
-        $thirdEnum = $extendedEnum::LAST_CONSTANT_NAME();
-
+        $firstEnum = MyEnum::CONSTANT_NAME();
+        $secondEnum = MyEnum::ANOTHER_CONSTANT_NAME();
+        $thirdEnum = MyEnum::LAST_CONSTANT_NAME();
 
         $this->assertTrue($firstEnum instanceof Enum);
         $this->assertTrue($secondEnum instanceof Enum);

--- a/tests/Unit/Common/Enum/EnumTest.php
+++ b/tests/Unit/Common/Enum/EnumTest.php
@@ -3,14 +3,8 @@ namespace Damianopetrungaro\CleanArchitecture\Unit\Common\Enum;
 
 use Damianopetrungaro\CleanArchitecture\Common\Enum\Enum;
 use Damianopetrungaro\CleanArchitecture\Common\Enum\EnumInterface;
+use Damianopetrungaro\CleanArchitecture\Unit\Common\Enum\Fixtures\MyEnum;
 use PHPUnit\Framework\TestCase;
-
-class MyEnum extends Enum
-{
-    protected const CONSTANT_NAME = 'this is a value';
-    protected const ANOTHER_CONSTANT_NAME = 'ANOTHER_CONSTANT_NAME';
-    protected const LAST_CONSTANT_NAME = 'Last!';
-}
 
 class EnumTest extends TestCase
 {
@@ -26,21 +20,50 @@ class EnumTest extends TestCase
     }
 
     /**
+     * Check that an InvalidArgumentException is thrown
+     *
+     * @expectedException \InvalidArgumentException
+     */
+    public function testConstructorInvalidArgumentException()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new MyEnum('NOT_EXISTS');
+    }
+
+    /**
      * Check that the call static method return the expected value
      *
      */
-    public function testValidEnum()
+    public function testValidEnumConstructor()
     {
-        $firstEnum = MyEnum::CONSTANT_NAME();
-        $secondEnum = MyEnum::ANOTHER_CONSTANT_NAME();
-        $thirdEnum = MyEnum::LAST_CONSTANT_NAME();
+        $firstEnum = new MyEnum(MyEnum::VALUE_A);
+        $secondEnum = new MyEnum(MyEnum::VALUE_B);
+        $thirdEnum = new MyEnum(MyEnum::VALUE_C);
 
-        $this->assertTrue($firstEnum instanceof Enum);
-        $this->assertTrue($secondEnum instanceof Enum);
-        $this->assertTrue($thirdEnum instanceof Enum);
+        $this->assertTrue($firstEnum instanceof EnumInterface);
+        $this->assertTrue($secondEnum instanceof EnumInterface);
+        $this->assertTrue($thirdEnum instanceof EnumInterface);
 
-        $this->assertEquals($firstEnum->getValue(), 'this is a value');
-        $this->assertEquals($secondEnum->getValue(), 'ANOTHER_CONSTANT_NAME');
-        $this->assertEquals($thirdEnum->getValue(), 'Last!');
+        $this->assertEquals($firstEnum->getValue(), 'A');
+        $this->assertEquals($secondEnum->getValue(), 'B');
+        $this->assertEquals($thirdEnum->getValue(), 'C');
+    }
+
+    /**
+     * Check that the call static method return the expected value
+     */
+    public function testValidEnumFactory()
+    {
+        $firstEnum = MyEnum::VALUE_A();
+        $secondEnum = MyEnum::VALUE_B();
+        $thirdEnum = MyEnum::VALUE_C();
+
+        $this->assertTrue($firstEnum instanceof EnumInterface);
+        $this->assertTrue($secondEnum instanceof EnumInterface);
+        $this->assertTrue($thirdEnum instanceof EnumInterface);
+
+        $this->assertEquals($firstEnum->getValue(), 'A');
+        $this->assertEquals($secondEnum->getValue(), 'B');
+        $this->assertEquals($thirdEnum->getValue(), 'C');
     }
 }

--- a/tests/Unit/Common/Enum/Fixtures/MyEnum.php
+++ b/tests/Unit/Common/Enum/Fixtures/MyEnum.php
@@ -4,9 +4,9 @@ namespace Damianopetrungaro\CleanArchitecture\Unit\Common\Enum\Fixtures;
 
 use Damianopetrungaro\CleanArchitecture\Common\Enum\Enum;
 
-class MyEnum extends Enum
+final class MyEnum extends Enum
 {
-    const VALUE_A = 'A';
-    const VALUE_B = 'B';
-    const VALUE_C = 'C';
+    const VALUE_A = 'VALUE_A';
+    const VALUE_B = 'VALUE_B';
+    const VALUE_C = 'VALUE_C';
 }

--- a/tests/Unit/Common/Enum/Fixtures/MyEnum.php
+++ b/tests/Unit/Common/Enum/Fixtures/MyEnum.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Damianopetrungaro\CleanArchitecture\Unit\Common\Enum\Fixtures;
+
+use Damianopetrungaro\CleanArchitecture\Common\Enum\Enum;
+
+class MyEnum extends Enum
+{
+    const VALUE_A = 'A';
+    const VALUE_B = 'B';
+    const VALUE_C = 'C';
+}


### PR DESCRIPTION
Solves https://github.com/damianopetrungaro/clean-architecture/issues/2

Now `Enum`s are immutables, you can instantiate it with `new MyEnum(MyEnum::MY_VALUE)` or the current behavior with factory `MyEnum::MY_VALUE()`.

Personally i prefer the first approach because I can use autocompletion and `findUsages` from my IDE.