### PR TITLE
feat(website): Use username instead of id for retrive user information

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,7 @@ Copyright (c) 2017 Damiano Petrungaro
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+to use, copy, modify, mergexcxccx, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
@@ -19,3 +19,4 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+cxxc


### PR DESCRIPTION
The identifier for fetch user data has become the username.
This allow us to be more visible on search engines and improve performance by 90% on user's API.

BREAKING CHANGE: Routes and repositories use username instead of the id
[PROJECTNAME-2837](http://jura.cim) | Pull Request #10 