### PR TITLE
type-hint Enum in Enum itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,3 +150,10 @@ There are some books that helped me to "think" in this way. Here some of them:
 
   This is a simple example of a TODO list of users, using slim microframework and clean architecture package.
   For any doubt or info add an issue.
+
+## Changelog
+
+#### [0.4] 2018-06-01 
+
+- [BC] added a type-hing to `Enum` interface. You need to adapt `equals` method in your class implementing
+  such inteface (or extending `ReflectionEnum` class)

--- a/src/Common/Enum/Enum.php
+++ b/src/Common/Enum/Enum.php
@@ -52,11 +52,11 @@ interface Enum
     /**
      * Returns TRUE if it equals $enum.
      *
-     * @param mixed $enum
+     * @param Enum $enum
      *
      * @return bool
      */
-    public function equals($enum): bool;
+    public function equals(Enum $enum): bool;
 
     /**
      * Returns the enum value as string

--- a/src/Common/Enum/ReflectionEnum.php
+++ b/src/Common/Enum/ReflectionEnum.php
@@ -65,7 +65,7 @@ abstract class ReflectionEnum implements Enum
     /**
      * {@inheritDoc}
      */
-    public abstract function equals($enum): bool;
+    abstract public function equals(Enum $enum): bool;
 
     /**
      * {@inheritDoc}

--- a/tests/Unit/Common/Enum/Fixtures/FixtureEnum.php
+++ b/tests/Unit/Common/Enum/Fixtures/FixtureEnum.php
@@ -2,6 +2,7 @@
 
 namespace Damianopetrungaro\CleanArchitecture\Unit\Common\Enum\Fixtures;
 
+use Damianopetrungaro\CleanArchitecture\Common\Enum\Enum;
 use Damianopetrungaro\CleanArchitecture\Common\Enum\ReflectionEnum;
 
 /**
@@ -17,7 +18,7 @@ final class FixtureEnum extends ReflectionEnum
     const C = 'VALUE_C';
     const VALUE_NUMB = 12;
 
-    public function equals($enum): bool
+    public function equals(Enum $enum): bool
     {
         // TODO: Implement equals() method.
     }


### PR DESCRIPTION
Also, fix order of abstract/visibility, as per [PSR-2](https://www.php-fig.org/psr/psr-2/#1-overview).

This change is a BC break, since it changes an interface.
While this is allowed before `1.0` tag, I think that it should be documented.